### PR TITLE
Upgraded task-buffer to V4

### DIFF
--- a/task-buffer/task-buffer.test.ts
+++ b/task-buffer/task-buffer.test.ts
@@ -1,4 +1,4 @@
-import { run, sleep, spawn, type Task } from "effection";
+import { run, sleep, spawn, type Task } from "npm:effection@4.0.0-alpha.3";
 import { describe, it } from "bdd";
 import { expect } from "expect";
 import { useTaskBuffer } from "./task-buffer.ts";
@@ -37,6 +37,7 @@ describe("TaskBuffer", () => {
           finished++;
         });
       }
+
       expect(finished).toEqual(0);
 
       yield* buffer;

--- a/task-buffer/task-buffer.ts
+++ b/task-buffer/task-buffer.ts
@@ -99,7 +99,7 @@ export function useTaskBuffer(max: number): Operation<TaskBuffer> {
           yield* sleep(0);
         }
       },
-      spawn: function* <T>(operation: () => Operation<T>) {
+      *spawn<T>(operation: () => Operation<T>) {
         const resolvers = withResolvers<Task<T>>();
 
         yield* input.send({

--- a/task-buffer/task-buffer.ts
+++ b/task-buffer/task-buffer.ts
@@ -99,14 +99,14 @@ export function useTaskBuffer(max: number): Operation<TaskBuffer> {
         }
       },
       *spawn<T>(operation: () => Operation<T>) {
-        const resolvers = withResolvers<Task<T>>();
+        let spawned = withResolvers<Task<T>>();
 
         yield* input.send({
           operation,
-          resolve: resolvers.resolve as Resolve<Task<unknown>>,
+          resolve: spawned.resolve as Resolve<Task<unknown>>,
         });
 
-        return yield* resolvers.operation;
+        return yield* spawned.operation;
       },
     });
   });


### PR DESCRIPTION
## Motivation

I needed the Task Buffer to track FS write operations, but I needed it in V4. 
 
## Approach

1. The Result type is not exported from V4, so I used V3
2. Replaced action with withResolvers
3. Move `sleep(0)` to iterable to give a bit of time between iterations

## TODO
