### PR TITLE
Made it possible to specify description with --- block

### DIFF
--- a/websocket/README.md
+++ b/websocket/README.md
@@ -6,14 +6,15 @@ of 'open', 'close', 'error', and 'message' event handlers, `useWebSocket()`
 organizes them for you so that you can consume all events from the server as a
 plain stream that has state-readiness and proper error handling baked in.
 
+---
+
 To use a websocket import the `useWebSocket()` operation which behaves just like
 the [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
 constructor.
 
 ```ts
 import { main, each } from "effection";
-import { useWebSocket } from "
-
+import { useWebSocket } from "@effection-contrib/websocket";
 
 await main(function*() {
   let socket = yield* useWebSocket("ws://websocket.example.org");
@@ -39,7 +40,7 @@ You can also instantiate a websocket separately and pass it along to
 `useWebSocket()`. This is helpful for runtimes such as NodeJS prior to version
 21 that do not have built in support for websocket.
 
-```
+```ts
 import { createWebSocket } from "my-websocket-client";
 
 await main(function*() {

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -13,16 +13,16 @@ the [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
 constructor.
 
 ```ts
-import { main, each } from "effection";
+import { each, main } from "effection";
 import { useWebSocket } from "@effection-contrib/websocket";
 
-await main(function*() {
+await main(function* () {
   let socket = yield* useWebSocket("ws://websocket.example.org");
 
   socket.send("Hello World");
 
   for (let message of yield* each(socket)) {
-    console.log('Message from server', message);
+    console.log("Message from server", message);
     yield* each.next();
   }
 });
@@ -43,11 +43,13 @@ You can also instantiate a websocket separately and pass it along to
 ```ts
 import { createWebSocket } from "my-websocket-client";
 
-await main(function*() {
-  let socket = yield* useWebSocket(() => createWebSocket("ws://websocket.example.org"));
+await main(function* () {
+  let socket = yield* useWebSocket(() =>
+    createWebSocket("ws://websocket.example.org")
+  );
 
   for (let message of yield* each(socket)) {
-    console.log('Message from server', message);
+    console.log("Message from server", message);
     yield* each.next();
   }
 });

--- a/www/assets/prism-atom-one-dark.css
+++ b/www/assets/prism-atom-one-dark.css
@@ -2,7 +2,7 @@
  * Added to make line numbering and higlight selection work:
  * https://github.com/timlrx/rehype-prism-plus#styling
  */
- pre {
+pre {
   overflow-x: auto;
 }
 
@@ -22,7 +22,13 @@
   padding-right: 16px;
   margin-left: -16px;
   margin-right: -16px;
-  border-left: 4px solid rgba(0, 0, 0, 0); /* Set placeholder for highlight accent border color to transparent */
+  border-left: 4px solid
+    rgba(
+      0,
+      0,
+      0,
+      0
+    ); /* Set placeholder for highlight accent border color to transparent */
 }
 
 .code-line.inserted {
@@ -37,7 +43,8 @@
   margin-left: -16px;
   margin-right: -16px;
   background-color: rgba(55, 65, 81, 0.5); /* Set highlight bg color */
-  border-left: 4px solid rgb(59, 130, 246); /* Set highlight accent border color */
+  border-left: 4px solid
+    rgb(59, 130, 246); /* Set highlight accent border color */
 }
 
 .line-number::before {
@@ -82,75 +89,81 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-	background: hsl(220, 13%, 18%);
-	color: hsl(220, 14%, 71%);
-	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-	font-family: "Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace;
-	direction: ltr;
-	text-align: left;
-	white-space: pre;
-	word-spacing: normal;
-	word-break: normal;
-	line-height: 1.5;
-	-moz-tab-size: 2;
-	-o-tab-size: 2;
-	tab-size: 2;
-	-webkit-hyphens: none;
-	-moz-hyphens: none;
-	-ms-hyphens: none;
-	hyphens: none;
+  background: hsl(220, 13%, 18%);
+  color: hsl(220, 14%, 71%);
+  text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+  font-family:
+    "Fira Code",
+    "Fira Mono",
+    Menlo,
+    Consolas,
+    "DejaVu Sans Mono",
+    monospace;
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.5;
+  -moz-tab-size: 2;
+  -o-tab-size: 2;
+  tab-size: 2;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
 }
 
 /* Selection */
 code[class*="language-"]::-moz-selection,
 code[class*="language-"] *::-moz-selection,
 pre[class*="language-"] *::-moz-selection {
-	background: hsl(220, 13%, 28%);
-	color: inherit;
-	text-shadow: none;
+  background: hsl(220, 13%, 28%);
+  color: inherit;
+  text-shadow: none;
 }
 
 code[class*="language-"]::selection,
 code[class*="language-"] *::selection,
 pre[class*="language-"] *::selection {
-	background: hsl(220, 13%, 28%);
-	color: inherit;
-	text-shadow: none;
+  background: hsl(220, 13%, 28%);
+  color: inherit;
+  text-shadow: none;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-	padding: 1em;
-	margin: 0.5em 0;
-	overflow: auto;
-	border-radius: 0.3em;
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-	padding: 0.2em 0.3em;
-	border-radius: 0.3em;
-	white-space: normal;
+  padding: 0.2em 0.3em;
+  border-radius: 0.3em;
+  white-space: normal;
 }
 
 /* Print */
 @media print {
-	code[class*="language-"],
-	pre[class*="language-"] {
-		text-shadow: none;
-	}
+  code[class*="language-"],
+  pre[class*="language-"] {
+    text-shadow: none;
+  }
 }
 
 .token.comment,
 .token.prolog,
 .token.cdata {
-	color: hsl(220, 10%, 40%);
+  color: hsl(220, 10%, 40%);
 }
 
 .token.doctype,
 .token.punctuation,
 .token.entity {
-	color: hsl(220, 14%, 71%);
+  color: hsl(220, 14%, 71%);
 }
 
 .token.attr-name,
@@ -159,11 +172,11 @@ pre[class*="language-"] {
 .token.constant,
 .token.number,
 .token.atrule {
-	color: hsl(29, 54%, 61%);
+  color: hsl(29, 54%, 61%);
 }
 
 .token.keyword {
-	color: hsl(286, 60%, 67%);
+  color: hsl(286, 60%, 67%);
 }
 
 .token.property,
@@ -171,7 +184,7 @@ pre[class*="language-"] {
 .token.symbol,
 .token.deleted,
 .token.important {
-	color: hsl(355, 65%, 65%);
+  color: hsl(355, 65%, 65%);
 }
 
 .token.selector,
@@ -182,123 +195,126 @@ pre[class*="language-"] {
 .token.regex,
 .token.attr-value,
 .token.attr-value > .token.punctuation {
-	color: hsl(95, 38%, 62%);
+  color: hsl(95, 38%, 62%);
 }
 
 .token.variable,
 .token.operator,
 .token.function {
-	color: hsl(207, 82%, 66%);
+  color: hsl(207, 82%, 66%);
 }
 
 .token.url {
-	color: hsl(187, 47%, 55%);
+  color: hsl(187, 47%, 55%);
 }
 
 /* HTML overrides */
 .token.attr-value > .token.punctuation.attr-equals,
 .token.special-attr > .token.attr-value > .token.value.css {
-	color: hsl(220, 14%, 71%);
+  color: hsl(220, 14%, 71%);
 }
 
 /* CSS overrides */
 .language-css .token.selector {
-	color: hsl(355, 65%, 65%);
+  color: hsl(355, 65%, 65%);
 }
 
 .language-css .token.property {
-	color: hsl(220, 14%, 71%);
+  color: hsl(220, 14%, 71%);
 }
 
 .language-css .token.function,
 .language-css .token.url > .token.function {
-	color: hsl(187, 47%, 55%);
+  color: hsl(187, 47%, 55%);
 }
 
 .language-css .token.url > .token.string.url {
-	color: hsl(95, 38%, 62%);
+  color: hsl(95, 38%, 62%);
 }
 
 .language-css .token.important,
 .language-css .token.atrule .token.rule {
-	color: hsl(286, 60%, 67%);
+  color: hsl(286, 60%, 67%);
 }
 
 /* JS overrides */
 .language-javascript .token.operator {
-	color: hsl(286, 60%, 67%);
+  color: hsl(286, 60%, 67%);
 }
 
-.language-javascript .token.template-string > .token.interpolation > .token.interpolation-punctuation.punctuation {
-	color: hsl(5, 48%, 51%);
+.language-javascript
+  .token.template-string
+  > .token.interpolation
+  > .token.interpolation-punctuation.punctuation {
+  color: hsl(5, 48%, 51%);
 }
 
 /* JSON overrides */
 .language-json .token.operator {
-	color: hsl(220, 14%, 71%);
+  color: hsl(220, 14%, 71%);
 }
 
 .language-json .token.null.keyword {
-	color: hsl(29, 54%, 61%);
+  color: hsl(29, 54%, 61%);
 }
 
 /* MD overrides */
 .language-markdown .token.url,
 .language-markdown .token.url > .token.operator,
 .language-markdown .token.url-reference.url > .token.string {
-	color: hsl(220, 14%, 71%);
+  color: hsl(220, 14%, 71%);
 }
 
 .language-markdown .token.url > .token.content {
-	color: hsl(207, 82%, 66%);
+  color: hsl(207, 82%, 66%);
 }
 
 .language-markdown .token.url > .token.url,
 .language-markdown .token.url-reference.url {
-	color: hsl(187, 47%, 55%);
+  color: hsl(187, 47%, 55%);
 }
 
 .language-markdown .token.blockquote.punctuation,
 .language-markdown .token.hr.punctuation {
-	color: hsl(220, 10%, 40%);
-	font-style: italic;
+  color: hsl(220, 10%, 40%);
+  font-style: italic;
 }
 
 .language-markdown .token.code-snippet {
-	color: hsl(95, 38%, 62%);
+  color: hsl(95, 38%, 62%);
 }
 
 .language-markdown .token.bold .token.content {
-	color: hsl(29, 54%, 61%);
+  color: hsl(29, 54%, 61%);
 }
 
 .language-markdown .token.italic .token.content {
-	color: hsl(286, 60%, 67%);
+  color: hsl(286, 60%, 67%);
 }
 
 .language-markdown .token.strike .token.content,
 .language-markdown .token.strike .token.punctuation,
 .language-markdown .token.list.punctuation,
 .language-markdown .token.title.important > .token.punctuation {
-	color: hsl(355, 65%, 65%);
+  color: hsl(355, 65%, 65%);
 }
 
 /* General */
 .token.bold {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 .token.comment,
 .token.italic {
-	font-style: italic;
+  font-style: italic;
 }
 
 .token.entity {
-	cursor: help;
+  cursor: help;
 }
 
 .token.namespace {
-	opacity: 0.8;
+  opacity: 0.8;
 }
 
 /* Plugin overrides */
@@ -309,24 +325,24 @@ pre[class*="language-"] {
 .token.token.cr:before,
 .token.token.lf:before,
 .token.token.space:before {
-	color: hsla(220, 14%, 71%, 0.15);
-	text-shadow: none;
+  color: hsla(220, 14%, 71%, 0.15);
+  text-shadow: none;
 }
 
 /* Toolbar plugin overrides */
 /* Space out all buttons and move them away from the right edge of the code block */
 div.code-toolbar > .toolbar.toolbar > .toolbar-item {
-	margin-right: 0.4em;
+  margin-right: 0.4em;
 }
 
 /* Styling the buttons */
 div.code-toolbar > .toolbar.toolbar > .toolbar-item > button,
 div.code-toolbar > .toolbar.toolbar > .toolbar-item > a,
 div.code-toolbar > .toolbar.toolbar > .toolbar-item > span {
-	background: hsl(220, 13%, 26%);
-	color: hsl(220, 9%, 55%);
-	padding: 0.1em 0.4em;
-	border-radius: 0.3em;
+  background: hsl(220, 13%, 26%);
+  color: hsl(220, 9%, 55%);
+  padding: 0.1em 0.4em;
+  border-radius: 0.3em;
 }
 
 div.code-toolbar > .toolbar.toolbar > .toolbar-item > button:hover,
@@ -335,43 +351,45 @@ div.code-toolbar > .toolbar.toolbar > .toolbar-item > a:hover,
 div.code-toolbar > .toolbar.toolbar > .toolbar-item > a:focus,
 div.code-toolbar > .toolbar.toolbar > .toolbar-item > span:hover,
 div.code-toolbar > .toolbar.toolbar > .toolbar-item > span:focus {
-	background: hsl(220, 13%, 28%);
-	color: hsl(220, 14%, 71%);
+  background: hsl(220, 13%, 28%);
+  color: hsl(220, 14%, 71%);
 }
 
 /* Line Highlight plugin overrides */
 /* The highlighted line itself */
 .line-highlight.line-highlight {
-	background: hsla(220, 100%, 80%, 0.04);
+  background: hsla(220, 100%, 80%, 0.04);
 }
 
 /* Default line numbers in Line Highlight plugin */
 .line-highlight.line-highlight:before,
 .line-highlight.line-highlight[data-end]:after {
-	background: hsl(220, 13%, 26%);
-	color: hsl(220, 14%, 71%);
-	padding: 0.1em 0.6em;
-	border-radius: 0.3em;
-	box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.2); /* same as Toolbar plugin default */
+  background: hsl(220, 13%, 26%);
+  color: hsl(220, 14%, 71%);
+  padding: 0.1em 0.6em;
+  border-radius: 0.3em;
+  box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.2); /* same as Toolbar plugin default */
 }
 
 /* Hovering over a linkable line number (in the gutter area) */
 /* Requires Line Numbers plugin as well */
-pre[id].linkable-line-numbers.linkable-line-numbers span.line-numbers-rows > span:hover:before {
-	background-color: hsla(220, 100%, 80%, 0.04);
+pre[id].linkable-line-numbers.linkable-line-numbers
+  span.line-numbers-rows
+  > span:hover:before {
+  background-color: hsla(220, 100%, 80%, 0.04);
 }
 
 /* Line Numbers and Command Line plugins overrides */
 /* Line separating gutter from coding area */
 .line-numbers.line-numbers .line-numbers-rows,
 .command-line .command-line-prompt {
-	border-right-color: hsla(220, 14%, 71%, 0.15);
+  border-right-color: hsla(220, 14%, 71%, 0.15);
 }
 
 /* Stuff in the gutter */
 .line-numbers .line-numbers-rows > span:before,
 .command-line .command-line-prompt > span:before {
-	color: hsl(220, 14%, 45%);
+  color: hsl(220, 14%, 45%);
 }
 
 /* Match Braces plugin overrides */
@@ -379,65 +397,65 @@ pre[id].linkable-line-numbers.linkable-line-numbers span.line-numbers-rows > spa
 .rainbow-braces .token.token.punctuation.brace-level-1,
 .rainbow-braces .token.token.punctuation.brace-level-5,
 .rainbow-braces .token.token.punctuation.brace-level-9 {
-	color: hsl(355, 65%, 65%);
+  color: hsl(355, 65%, 65%);
 }
 
 .rainbow-braces .token.token.punctuation.brace-level-2,
 .rainbow-braces .token.token.punctuation.brace-level-6,
 .rainbow-braces .token.token.punctuation.brace-level-10 {
-	color: hsl(95, 38%, 62%);
+  color: hsl(95, 38%, 62%);
 }
 
 .rainbow-braces .token.token.punctuation.brace-level-3,
 .rainbow-braces .token.token.punctuation.brace-level-7,
 .rainbow-braces .token.token.punctuation.brace-level-11 {
-	color: hsl(207, 82%, 66%);
+  color: hsl(207, 82%, 66%);
 }
 
 .rainbow-braces .token.token.punctuation.brace-level-4,
 .rainbow-braces .token.token.punctuation.brace-level-8,
 .rainbow-braces .token.token.punctuation.brace-level-12 {
-	color: hsl(286, 60%, 67%);
+  color: hsl(286, 60%, 67%);
 }
 
 /* Diff Highlight plugin overrides */
 /* Taken from https://github.com/atom/github/blob/master/styles/variables.less */
 pre.diff-highlight > code .token.token.deleted:not(.prefix),
 pre > code.diff-highlight .token.token.deleted:not(.prefix) {
-	background-color: hsla(353, 100%, 66%, 0.15);
+  background-color: hsla(353, 100%, 66%, 0.15);
 }
 
 pre.diff-highlight > code .token.token.deleted:not(.prefix)::-moz-selection,
 pre.diff-highlight > code .token.token.deleted:not(.prefix) *::-moz-selection,
 pre > code.diff-highlight .token.token.deleted:not(.prefix)::-moz-selection,
 pre > code.diff-highlight .token.token.deleted:not(.prefix) *::-moz-selection {
-	background-color: hsla(353, 95%, 66%, 0.25);
+  background-color: hsla(353, 95%, 66%, 0.25);
 }
 
 pre.diff-highlight > code .token.token.deleted:not(.prefix)::selection,
 pre.diff-highlight > code .token.token.deleted:not(.prefix) *::selection,
 pre > code.diff-highlight .token.token.deleted:not(.prefix)::selection,
 pre > code.diff-highlight .token.token.deleted:not(.prefix) *::selection {
-	background-color: hsla(353, 95%, 66%, 0.25);
+  background-color: hsla(353, 95%, 66%, 0.25);
 }
 
 pre.diff-highlight > code .token.token.inserted:not(.prefix),
 pre > code.diff-highlight .token.token.inserted:not(.prefix) {
-	background-color: hsla(137, 100%, 55%, 0.15);
+  background-color: hsla(137, 100%, 55%, 0.15);
 }
 
 pre.diff-highlight > code .token.token.inserted:not(.prefix)::-moz-selection,
 pre.diff-highlight > code .token.token.inserted:not(.prefix) *::-moz-selection,
 pre > code.diff-highlight .token.token.inserted:not(.prefix)::-moz-selection,
 pre > code.diff-highlight .token.token.inserted:not(.prefix) *::-moz-selection {
-	background-color: hsla(135, 73%, 55%, 0.25);
+  background-color: hsla(135, 73%, 55%, 0.25);
 }
 
 pre.diff-highlight > code .token.token.inserted:not(.prefix)::selection,
 pre.diff-highlight > code .token.token.inserted:not(.prefix) *::selection,
 pre > code.diff-highlight .token.token.inserted:not(.prefix)::selection,
 pre > code.diff-highlight .token.token.inserted:not(.prefix) *::selection {
-	background-color: hsla(135, 73%, 55%, 0.25);
+  background-color: hsla(135, 73%, 55%, 0.25);
 }
 
 /* Previewers plugin overrides */
@@ -445,48 +463,48 @@ pre > code.diff-highlight .token.token.inserted:not(.prefix) *::selection {
 /* Border around popup */
 .prism-previewer.prism-previewer:before,
 .prism-previewer-gradient.prism-previewer-gradient div {
-	border-color: hsl(224, 13%, 17%);
+  border-color: hsl(224, 13%, 17%);
 }
 
 /* Angle and time should remain as circles and are hence not included */
 .prism-previewer-color.prism-previewer-color:before,
 .prism-previewer-gradient.prism-previewer-gradient div,
 .prism-previewer-easing.prism-previewer-easing:before {
-	border-radius: 0.3em;
+  border-radius: 0.3em;
 }
 
 /* Triangles pointing to the code */
 .prism-previewer.prism-previewer:after {
-	border-top-color: hsl(224, 13%, 17%);
+  border-top-color: hsl(224, 13%, 17%);
 }
 
 .prism-previewer-flipped.prism-previewer-flipped.after {
-	border-bottom-color: hsl(224, 13%, 17%);
+  border-bottom-color: hsl(224, 13%, 17%);
 }
 
 /* Background colour within the popup */
 .prism-previewer-angle.prism-previewer-angle:before,
 .prism-previewer-time.prism-previewer-time:before,
 .prism-previewer-easing.prism-previewer-easing {
-	background: hsl(219, 13%, 22%);
+  background: hsl(219, 13%, 22%);
 }
 
 /* For angle, this is the positive area (eg. 90deg will display one quadrant in this colour) */
 /* For time, this is the alternate colour */
 .prism-previewer-angle.prism-previewer-angle circle,
 .prism-previewer-time.prism-previewer-time circle {
-	stroke: hsl(220, 14%, 71%);
-	stroke-opacity: 1;
+  stroke: hsl(220, 14%, 71%);
+  stroke-opacity: 1;
 }
 
 /* Stroke colours of the handle, direction point, and vector itself */
 .prism-previewer-easing.prism-previewer-easing circle,
 .prism-previewer-easing.prism-previewer-easing path,
 .prism-previewer-easing.prism-previewer-easing line {
-	stroke: hsl(220, 14%, 71%);
+  stroke: hsl(220, 14%, 71%);
 }
 
 /* Fill colour of the handle */
 .prism-previewer-easing.prism-previewer-easing circle {
-	fill: transparent;
+  fill: transparent;
 }

--- a/www/components/rehype.tsx
+++ b/www/components/rehype.tsx
@@ -30,7 +30,7 @@ export function Rehype({ children }: RehypeProps) {
           {
             "h1[id],h2[id],h3[id],h4[id],h5[id],h6[id]": "group",
             pre: "grid",
-          },
+          }
         ],
       ]}
     >

--- a/www/components/rehype.tsx
+++ b/www/components/rehype.tsx
@@ -30,7 +30,7 @@ export function Rehype({ children }: RehypeProps) {
           {
             "h1[id],h2[id],h3[id],h4[id],h5[id],h6[id]": "group",
             pre: "grid",
-          }
+          },
         ],
       ]}
     >

--- a/www/hooks/use-description-parse.tsx
+++ b/www/hooks/use-description-parse.tsx
@@ -8,13 +8,15 @@ import rehypeInferDescriptionMeta from "npm:rehype-infer-description-meta@2.0.0"
 import rehypeStringify from "npm:rehype-stringify@10.0.1";
 import remarkParse from "npm:remark-parse@11.0.0";
 import remarkRehype from "npm:remark-rehype@11.1.1";
+import { trimAfterHR } from "../lib/trim-after-hr.ts";
 
-export function* useRemarkParse(markdown: string): Operation<VFile> {
+export function* useDescriptionParse(markdown: string): Operation<VFile> {
   return yield* call(() =>
     unified()
       .use(remarkParse)
       .use(remarkRehype)
       .use(rehypeStringify)
+      .use(trimAfterHR)
       .use(rehypeInferDescriptionMeta, {
         inferDescriptionHast: true,
         truncateSize: 400,

--- a/www/hooks/use-mdx.tsx
+++ b/www/hooks/use-mdx.tsx
@@ -17,7 +17,9 @@ export function* useMDX(markdown: string): Operation<MDXModule> {
       jsxDEV: jsx,
       Fragment,
       remarkPlugins: [remarkGfm],
-      rehypePlugins: [[removeDescriptionHR], [rehypePrismPlus, { showLineNumbers: true }]],
+      rehypePlugins: [[removeDescriptionHR], [rehypePrismPlus, {
+        showLineNumbers: true,
+      }]],
     })
   );
 }

--- a/www/hooks/use-mdx.tsx
+++ b/www/hooks/use-mdx.tsx
@@ -4,6 +4,7 @@ import type { MDXModule } from "npm:@types/mdx@2.0.13";
 import rehypePrismPlus from "npm:rehype-prism-plus@2.0.0";
 import remarkGfm from "npm:remark-gfm@4.0.0";
 import { Fragment, jsx, jsxs } from "revolution/jsx-runtime";
+import { removeDescriptionHR } from "../lib/remove-description-hr.ts";
 
 export function* useMDX(markdown: string): Operation<MDXModule> {
   return yield* call(() =>
@@ -16,7 +17,7 @@ export function* useMDX(markdown: string): Operation<MDXModule> {
       jsxDEV: jsx,
       Fragment,
       remarkPlugins: [remarkGfm],
-      rehypePlugins: [[rehypePrismPlus, { showLineNumbers: true }]],
+      rehypePlugins: [[removeDescriptionHR], [rehypePrismPlus, { showLineNumbers: true }]],
     })
   );
 }

--- a/www/hooks/use-package.tsx
+++ b/www/hooks/use-package.tsx
@@ -7,7 +7,7 @@ import type { JSXElement } from "revolution";
 import { PrivatePackageError } from "../errors.ts";
 import { type DocNode, useDenoDoc } from "./use-deno-doc.tsx";
 import { useMDX } from "./use-mdx.tsx";
-import { useRemarkParse } from "./use-remark-parse.tsx";
+import { useDescriptionParse } from "./use-description-parse.tsx";
 
 export interface Package {
   path: string;
@@ -61,7 +61,7 @@ export function* usePackage(workspace: string): Operation<Package> {
 
   const content = mod.default({});
 
-  let file: VFile = yield* useRemarkParse(readme);
+  let file: VFile = yield* useDescriptionParse(readme);
 
   const exports = typeof denoJson.exports === "string"
     ? {

--- a/www/lib/remove-description-hr.ts
+++ b/www/lib/remove-description-hr.ts
@@ -1,0 +1,28 @@
+import { EXIT, visit } from "npm:unist-util-visit@5.0.0";
+import type { Node } from "npm:@types/unist@3.0.3";
+
+/**
+ * Remove the HR element used to define the end of the description.
+ */
+export function removeDescriptionHR() {
+  return function (tree: Node) {
+    return visit(tree, (node, index, parent) => {
+      if (
+        node.type === "element" && node.tagName === "hr" &&
+        parent.type === "root"
+      ) {
+        const beforeHR = parent.children
+          .slice(0, index)
+          .filter(node => !(node.type === "text" && node.value === "\n"));
+
+        // assume this hr is for a description if there are only two elements and
+        // second element is a paragraph.
+        if (beforeHR.length === 2 && beforeHR[1].type === "element" && beforeHR[1].tagName === "p") {
+          parent.children = parent.children.filter(child => child !== node);
+        }
+        
+        return EXIT;
+      }
+    });
+  };
+}

--- a/www/lib/remove-description-hr.ts
+++ b/www/lib/remove-description-hr.ts
@@ -13,14 +13,17 @@ export function removeDescriptionHR() {
       ) {
         const beforeHR = parent.children
           .slice(0, index)
-          .filter(node => !(node.type === "text" && node.value === "\n"));
+          .filter((node) => !(node.type === "text" && node.value === "\n"));
 
         // assume this hr is for a description if there are only two elements and
         // second element is a paragraph.
-        if (beforeHR.length === 2 && beforeHR[1].type === "element" && beforeHR[1].tagName === "p") {
-          parent.children = parent.children.filter(child => child !== node);
+        if (
+          beforeHR.length === 2 && beforeHR[1].type === "element" &&
+          beforeHR[1].tagName === "p"
+        ) {
+          parent.children = parent.children.filter((child) => child !== node);
         }
-        
+
         return EXIT;
       }
     });

--- a/www/lib/trim-after-hr.ts
+++ b/www/lib/trim-after-hr.ts
@@ -13,7 +13,6 @@ export function trimAfterHR() {
         node.type === "element" && node.tagName === "hr" &&
         parent.type === "root"
       ) {
-        // console.log({node, index, parent})
         parent.children = parent.children.slice(0, index);
         return EXIT;
       }

--- a/www/lib/trim-after-hr.ts
+++ b/www/lib/trim-after-hr.ts
@@ -1,0 +1,22 @@
+import { EXIT, visit } from "npm:unist-util-visit@5.0.0";
+import type { Node } from "npm:@types/unist@3.0.3";
+
+/**
+ * Removes all content after <hr /> in the root element.
+ * This is used to restrict the length of the description by eliminating everything after <hr />
+ * @returns
+ */
+export function trimAfterHR() {
+  return function (tree: Node) {
+    return visit(tree, (node, index, parent) => {
+      if (
+        node.type === "element" && node.tagName === "hr" &&
+        parent.type === "root"
+      ) {
+        // console.log({node, index, parent})
+        parent.children = parent.children.slice(0, index);
+        return EXIT;
+      }
+    });
+  };
+}

--- a/www/main.ts
+++ b/www/main.ts
@@ -38,7 +38,11 @@ if (import.meta.main) {
   });
 }
 
-
 function urlFromServer(server: ServerInfo) {
-  return new URL("/", `http://${server.hostname === "0.0.0.0" ? "localhost" : server.hostname}:${server.port}`);
+  return new URL(
+    "/",
+    `http://${
+      server.hostname === "0.0.0.0" ? "localhost" : server.hostname
+    }:${server.port}`,
+  );
 }

--- a/www/main.ts
+++ b/www/main.ts
@@ -1,5 +1,5 @@
 import { main, suspend } from "effection";
-import { createRevolution } from "revolution";
+import { createRevolution, ServerInfo } from "revolution";
 import { initDenoDeploy } from "../deno-deploy/mod.ts";
 
 import { config } from "effection-www/tailwind.config.ts";
@@ -32,8 +32,13 @@ if (import.meta.main) {
     });
 
     let server = yield* revolution.start();
-    console.log(`www -> http://${server.hostname}:${server.port}`);
+    console.log(`www -> ${urlFromServer(server)}`);
 
     yield* suspend();
   });
+}
+
+
+function urlFromServer(server: ServerInfo) {
+  return new URL("/", `http://${server.hostname === "0.0.0.0" ? "localhost" : server.hostname}:${server.port}`);
 }


### PR DESCRIPTION
## Motivation

When the readme has a long description, we need a way to separate the description from the main body of the README. Previously, it would default to a max length which didn't always make sense. 

## Approach

Created a simple plugin to use before <rh> as a description.

## Screenshots

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/04c732e4-d9d7-41ab-bae2-0e20b9b104d7" />

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/ed74e646-5892-4e7f-becd-dcf6669985fb" />

