### PR TITLE
Make sure npm packages are tagged with latest

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - run: deno run -A www/tasks/build-npm.ts ${{matrix.workspace}}
 
-      - run: npm publish --access=public --tag=next
+      - run: npm publish --access=public --tag=latest
         working-directory: ${{matrix.workspace}}/build/npm
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Motivation

Some of the packages were not tagged correctly in npm because we were tagging them with next.

## Approach

Explicitly tag with latest. 