### PR TITLE
Eliminated jsonlines dependency in favour of built in types

### DIFF
--- a/jsonl-store/jsonl.test.ts
+++ b/jsonl-store/jsonl.test.ts
@@ -37,9 +37,17 @@ describe("JSONLStore", () => {
     store = JSONLStore.from({ location: tmpDir });
   });
 
-  it("has from constructor that ensures trailing slash", () => {
-    const store = JSONLStore.from({ location: "/foo" });
-    expect(`${store.location}`).toEqual("file:///foo/");
+  describe("from", () => {
+    it("ensures trailing slash for string path", () => {
+      const store = JSONLStore.from({ location: "/foo" });
+      expect(`${store.location}`).toEqual("file:///foo/");
+    });
+    it("ensures trailing slash for URL", () => {
+      const store = JSONLStore.from({
+        location: new URL(".cache", "file:///usr/"),
+      });
+      expect(`${store.location}`).toEqual("file:///usr/.cache/");
+    });
   });
 
   it("writes to a file", async () => {


### PR DESCRIPTION
## Motivation

jsonl-store failed to publish to JSR because it had a package from deno.land. 

## Approach

Fixing it sent me down a rabbit hole, but the outcome was useful. I found out that the package that I was using was actually published to NPM as `jsonlines-web` but it was also integrated into `jsr:@std/streaming` and `jsr:@std/json`. 

I was able to replace the dependency with `@std` packages. 

I also added a workflow that checks which directories were changed and runs the JSR publish dry-run command to test if it'll actually publish.  