### PR TITLE
Use JSR token to publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,8 +42,9 @@ jobs:
       - uses: actions/checkout@v4.2.0
       - uses: denoland/setup-deno@v2
 
-      - run: deno publish
+      - run: deno publish --token=${{ secrets.JSR_TOKEN }}
         working-directory: ${{ matrix.workspace }}
+
   npm:
     if: fromJSON(needs.generate-matrix.outputs.exists)
     name: Publish ${{ matrix.name }}@${{matrix.version}} to NPM


### PR DESCRIPTION
## Motivation

We want `effection-contrib` maintainers to be able to commit without having to be members of `effection-contrib` scope on JSR. We can do this by using Frontside Jack's JSR token.  

## Approach

Passing token to `deno publish`. 