### PR TITLE
🐛 Fix contrib sitemap

### DIFF
--- a/www/main.ts
+++ b/www/main.ts
@@ -1,4 +1,4 @@
-import { call, main, suspend } from "effection";
+import { main, suspend } from "effection";
 import { createRevolution, ServerInfo } from "revolution";
 import { initDenoDeploy } from "../deno-deploy/mod.ts";
 

--- a/www/routes/package.tsx
+++ b/www/routes/package.tsx
@@ -21,7 +21,7 @@ export function packageRoute(): SitemapRoute<JSXElement> {
       });
       for (let pkg of configs) {
         paths.push({
-          pathname: pathname({ workspace: pkg.workspace }),
+          pathname: pathname({ workspace: pkg.workspace.replace(/^\.\//, "") }),
         });
       }
       return paths;


### PR DESCRIPTION
## Motivation

The /sitemap.xml was broken, which is a critical component for static site generation, both for this site.

## Approach

It turns out that the `pkg.workspace` field was in the form of a relative path specifier which causes an error when you try and substitute it in for the `/:workspace` route.

This removes the string `"./"` from the front of any substitution.

### Open Questions


- [ ] Should we fix this at the field level? I.e. make `pkg.workspace` return a logical workspace name without the relative path specifier?

