### PR TITLE
added missing dependency information

### DIFF
--- a/tinyexec/deno.json
+++ b/tinyexec/deno.json
@@ -2,8 +2,5 @@
   "name": "@effection-contrib/tinyexec",
   "version": "0.1.0",
   "exports": "./mod.ts",
-  "imports": {
-    "tinyexec": "npm:tinyexec@0.3.0"
-  },
   "license": "MIT"
 }

--- a/tinyexec/tinyexec.ts
+++ b/tinyexec/tinyexec.ts
@@ -6,7 +6,7 @@ import {
   stream,
   useAbortSignal,
 } from "npm:effection@3.0.3";
-import { type KillSignal, type Options, type Output, x as $x } from "tinyexec";
+import { type KillSignal, type Options, type Output, x as $x } from "npm:tinyexec@0.3.2";
 
 export interface TinyProcess extends Operation<Output> {
   lines: Stream<string, void>;

--- a/tinyexec/tinyexec.ts
+++ b/tinyexec/tinyexec.ts
@@ -6,7 +6,12 @@ import {
   stream,
   useAbortSignal,
 } from "npm:effection@3.0.3";
-import { type KillSignal, type Options, type Output, x as $x } from "npm:tinyexec@0.3.2";
+import {
+  type KillSignal,
+  type Options,
+  type Output,
+  x as $x,
+} from "npm:tinyexec@0.3.2";
 
 export interface TinyProcess extends Operation<Output> {
   lines: Stream<string, void>;


### PR DESCRIPTION
## Motivation

Made Tinyexec dependency explicit in code to make code more easily copy and pastable.

## Approach

Added it explicitely


