### PR TITLE
📝 add api docs and readme examples for tinyexec

### DIFF
--- a/tinyexec/README.md
+++ b/tinyexec/README.md
@@ -2,3 +2,42 @@
 
 Effection compatible wrapper around
 [tinyexec](https://www.npmjs.com/package/tinyexec) package.
+
+To run a process, use the `x` function:
+
+```ts
+import { x } from "@effection-contrib/tinyexec";
+import { each, main } from "effection";
+
+await main(function* () {
+  let proc = yield* x("echo", ["Hello, World"]);
+
+  for (let line of yield* each(proc.lines)) {
+    console.log(line);
+    yield* each.next();
+  }
+});
+// => prints "Hello, World"
+```
+
+The process will be automatically destroyed whenever it passes out of scope. For
+example, the following shows the output of the `top` command for five seconds
+before exiting.
+
+```ts
+import { x } from "@effection-contrib/tinyexec";
+import { each, main, sleep, spawn } from "effection";
+
+await main(function* () {
+  yield* spawn(function* () {
+    let proc = yield* x("top");
+
+    for (let line of yield* each(proc.lines)) {
+      console.log(line);
+      yield* each.next();
+    }
+  });
+
+  yield* sleep(5000);
+});
+```

--- a/tinyexec/tinyexec.ts
+++ b/tinyexec/tinyexec.ts
@@ -4,7 +4,6 @@ import {
   resource,
   type Stream,
   stream,
-  useAbortSignal,
 } from "npm:effection@3.0.3";
 import {
   type KillSignal,
@@ -13,21 +12,38 @@ import {
   x as $x,
 } from "npm:tinyexec@0.3.2";
 
+/**
+ * Wraps a [tinyexec](https://github.com/tinylibs/tinyexec) process.
+ * To create one use the {@link x} function.
+ */
 export interface TinyProcess extends Operation<Output> {
+  /**
+   * A stream of lines coming from both stdin and stdout. The stream
+   * will terminate when stdout and stderr are closed which usually
+   * corresponds to the process ending.
+   */
   lines: Stream<string, void>;
 
+  /**
+   * Send `signal` to this process
+   * @paramu signal - the OS signal to send to the process
+   */
   kill(signal?: KillSignal): Operation<void>;
 }
 
+/**
+ * Run OS process with `cmd`
+ *
+ * This will create a {@link TinyProcess} resource. If it is still running
+ * when it passes out of scope, it will be killed.
+ */
 export function x(
   cmd: string,
   args: string[] = [],
   options?: Partial<Options>,
 ): Operation<TinyProcess> {
   return resource(function* (provide) {
-    let signal = yield* useAbortSignal();
-
-    let tinyexec = $x(cmd, args, { ...options, signal });
+    let tinyexec = $x(cmd, args, { ...options });
 
     let promise: Promise<Output> = tinyexec as unknown as Promise<Output>;
 


### PR DESCRIPTION
## Motivation

Docs are good if we want a contrib library to have a good score and be used.

![screenshot showing a JSR score of 70%](https://github.com/user-attachments/assets/bff074c9-bcaf-4095-adab-bfbdfb5083f1)

## Approach


This adds typedocs for the tinyexec package as well as some simple examples