### PR TITLE
🚨 fix linting errors

### DIFF
--- a/fx/parallel.ts
+++ b/fx/parallel.ts
@@ -61,7 +61,9 @@ export interface ParallelRet<T> extends Computation<Result<T>[]> {
  * }
  * ```
  */
-export function parallel<T>(operations: Callable<T>[]) {
+export function parallel<T>(
+  operations: Callable<T>[],
+): Operation<ParallelRet<T>> {
   const sequence = createChannel<Result<T>>();
   const immediate = createChannel<Result<T>>();
   const results: Result<T>[] = [];

--- a/fx/race.ts
+++ b/fx/race.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import type { Callable, Operation, Task } from "npm:effection@3.0.3";
 import { action, call, resource, spawn } from "npm:effection@3.0.3";
 

--- a/fx/request.ts
+++ b/fx/request.ts
@@ -1,12 +1,15 @@
-import { call, useAbortSignal } from "npm:effection@3.0.3";
+import { call, type Operation, useAbortSignal } from "npm:effection@3.0.3";
 
-export function* request(url: string | URL | Request, opts?: RequestInit) {
+export function* request(
+  url: string | URL | Request,
+  opts?: RequestInit,
+): Operation<Response> {
   const signal = yield* useAbortSignal();
-  const response = yield* call(fetch(url, { signal, ...opts }));
+  const response = yield* call(() => fetch(url, { signal, ...opts }));
   return response;
 }
 
-export function* json(response: Response) {
-  const result = yield* call(response.json());
-  return result;
+// deno-lint-ignore no-explicit-any
+export function* json(response: Response): Operation<any> {
+  return yield* call(() => response.json());
 }

--- a/fx/safe.ts
+++ b/fx/safe.ts
@@ -25,6 +25,7 @@ function isError(error: unknown): error is Error {
 
 export function* safe<T>(operator: Callable<T>): Operation<Result<T>> {
   try {
+    // deno-lint-ignore no-explicit-any
     const value = yield* call<T>(operator as any);
     return Ok(value);
   } catch (error) {


### PR DESCRIPTION
## Motivation

There were some linting errors that were causing our tests to fail.

## Approach

I fixed where I could, but wasn't sure what to do with the `any` casts, so I marked them as ignored. The fixes I applied required some formatting fixes.