### PR TITLE
Bumped task buffer to v4

### DIFF
--- a/task-buffer/deno.json
+++ b/task-buffer/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection-contrib/task-buffer",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "exports": "./mod.ts",
   "license": "MIT"
 }

--- a/task-buffer/task-buffer.ts
+++ b/task-buffer/task-buffer.ts
@@ -8,7 +8,7 @@ import {
   type Task,
   useScope,
   withResolvers,
-} from "npm:effection@4.0.0-alpha.3";
+} from "npm:effection@4.0.0-alpha.4";
 
 /**
  * Spawn operations, but only allow a certain number to be active at a


### PR DESCRIPTION
## Motivation

I want to replace task buffer in staticalize with the version from effection-contrib, but I need to upgrade it to v4.

## Approach

* Using v4 from npm
* Bumping to 1.0.0