### PR TITLE
🎉 Add @effection-contrib/timebox

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -39,6 +39,7 @@
     "./fx",
     "./task-buffer",
     "./tinyexec",
+    "./timebox",
     "./websocket"
   ],
   "deploy": {

--- a/timebox/README.md
+++ b/timebox/README.md
@@ -1,0 +1,27 @@
+# @effection-contrib/timebox
+
+Constrain any operation to complete within a certain time.
+
+---
+
+Very often you want to put a limit on how long an operation may run such as a
+`fetch()` of an external resource, or handling a web request. To do this, you
+can use the `timebox()` function. It will encapsulate the operation and either
+return its result, or a otherwise a "timeout" object indicating that it did not
+complete in the required time.
+
+```ts
+import { timebox } from "@effection-contrib/timebox";
+import { handleRequest } from "./handle-request";
+
+// a theoretical request handler
+export function* handler(request) {
+  // do not let the handler run for more than 10 seconds
+  let result = yield* timebox(10000, () => handleRequest(request));
+  if (result.timeout) {
+    return new Response(504, "Gateway Timeout");
+  } else {
+    return result.value;
+  }
+}
+```

--- a/timebox/deno.json
+++ b/timebox/deno.json
@@ -1,0 +1,6 @@
+{
+  "name": "@effection-contrib/timebox",
+  "version": "0.1.0",
+  "license": "MIT",
+  "exports": "./mod.ts"
+}

--- a/timebox/mod.ts
+++ b/timebox/mod.ts
@@ -1,0 +1,94 @@
+import type { Operation } from "npm:effection@^4.0.0-alpha.4";
+import { race, sleep } from "npm:effection@^4.0.0-alpha.4";
+
+/**
+ * Either a succesfully computed value, or one that took too long to complete.
+ */
+export type Timeboxed<T> = Completed<T> | Timeout;
+
+/**
+ * A value successfully computed within the timeout window. It has metadata about how long it
+ * took.
+ */
+export interface Completed<T> {
+  /**
+   * false: indicates that there was no timeout and that `value` was successfully computed
+   */
+  readonly timeout: false;
+
+  /**
+   * The actual value
+   */
+  readonly value: T;
+
+  /**
+   * The time that the operation began;
+   */
+  readonly start: DOMHighResTimeStamp;
+
+  /**
+   * The time that the operation succesfully returned {value}
+   */
+  readonly end: DOMHighResTimeStamp;
+}
+
+/**
+ * A value that did not compute within the alloted window.
+ */
+export interface Timeout {
+  /**
+   * true: indicates that this is a timed out result and no value is available
+   */
+  readonly timeout: true;
+
+  /**
+   * The time that the operation began;
+   */
+  readonly start: DOMHighResTimeStamp;
+
+  /**
+   * The time that the operation succesfully returned {value}
+   */
+  readonly end: DOMHighResTimeStamp;
+}
+
+/**
+ * Constrain `operation` to complete within `limitMS` milliseconds
+ *
+ * @example
+ * ```ts
+ * import { timebox } from "@effection-contrib/timebox";
+ * import { handleRequest } from "./handle-request";
+
+ * // a theoretical request handler
+ * export function* handler(request: Request): Operation<Response> {
+ *   // do not let the handler run for more than 10 seconds
+ *   let result = yield* timebox(10000, () => handleRequest(request));
+ *   if (result.timeout) {
+ *     return new Response(504, "Gateway Timeout");
+ *   } else {
+ *     return result.value;
+ *   }
+ * }
+ * ```
+ * @param limitMS - the maximum allowable time for `operation` to complete
+ * @param operation - the operation to attempt
+ * @returns either a completed value or a timeout
+ */
+export function timebox<T>(
+  limitMS: number,
+  operation: () => Operation<T>,
+): Operation<Timeboxed<T>> {
+  return race([complete(operation), deadline(limitMS)]);
+}
+
+function* deadline(limitMS: number): Operation<Timeout> {
+  let start = performance.now();
+  yield* sleep(limitMS);
+  return { timeout: true, start, end: performance.now() };
+}
+
+function* complete<T>(op: () => Operation<T>): Operation<Completed<T>> {
+  let start = performance.now();
+  return { timeout: false, value: yield* op(), start, end: performance.now() };
+}

--- a/timebox/timebox.test.ts
+++ b/timebox/timebox.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "bdd";
+import { expect } from "expect";
+import { timebox } from "./mod.ts";
+import {
+  type Operation,
+  run,
+  sleep,
+  suspend,
+} from "npm:effection@^4.0.0-alpha.4";
+
+describe("timebox", () => {
+  it("is completed if operation returns within alloted time", async () => {
+    let outcome = await run(() => timebox(100, delayed(5, () => "hello")));
+    outcome.timeout;
+    expect(outcome).toMatchObject({
+      timeout: false,
+      value: "hello",
+    });
+  });
+
+  it("is completed if operation throws within alloted time", async () => {
+    let task = run(() =>
+      timebox(
+        100,
+        delayed(5, () => {
+          throw new Error("boom!");
+        }),
+      )
+    );
+    await expect(task).rejects.toMatchObject({
+      message: "boom!",
+    });
+  });
+
+  it("is timed out if operation does not return within alloted time", async () => {
+    await expect(run(() => timebox(10, suspend))).resolves.toMatchObject({
+      timeout: true,
+    });
+  });
+});
+
+function delayed<T>(delayMS: number, value: () => T): () => Operation<T> {
+  return function* () {
+    yield* sleep(delayMS);
+    return value();
+  };
+}


### PR DESCRIPTION
## Motivation
Adding time constraints to any operation without having to change it at all is one of the most powerful demonstrations of how Effection composes. It is also needed to implement convergent assertions which we will need in many different locations, and which we may want to release as a library in of itself.

## Approach
This takes the essence of all the timeout implementations over the last 5 years and puts them into generally available "timebox" package. A key decision that makes this implementation more flexible than earlier implementations is it does not throw a "TimeoutError" when the operation exceeds the deadline. Rather, it returns a discriminated union indicating whether it completed successfuly, or if it timed out.
