### PR TITLE
Clean up Readme titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ more than a few times are welcome.
 1. Create a directory
 2. Add a deno.json file with
    `{ "name": "@effection-contrib/<you_package_name>", version: "0.1.0", "exports": "./mod.ts", "license": "MIT" }`
-3. Add a README.md (the first sentence of the README will be used as the
-   description)
+3. Add a README.md (text before `---` will be used as a description for the
+   package)
 4. Add your source code and export it from `mod.ts`
 5. Add doc strings to your source code - they will be used for documentation on
    the site.

--- a/deno-deploy/README.md
+++ b/deno-deploy/README.md
@@ -9,10 +9,10 @@ import { main } from "effection";
 import { useDenoDeploy } from "@effection-contrib/deno-deploy";
 
 await main(function* () {
-  const { 
-  isDenoDeploy,
-  deploymentId,
-  region 
+  const {
+    isDenoDeploy,
+    deploymentId,
+    region,
   } = yield* useDenoDeploy();
-})
+});
 ```

--- a/deno-deploy/README.md
+++ b/deno-deploy/README.md
@@ -3,3 +3,16 @@
 Provides Deno Deploy Effection context with `region`, `deploymentId` and
 `isDenoDeploy` flag to detect when running in the Deno Deploy environment. This
 can be useful when testing an application that's deployed to Deno Deploy.
+
+```ts
+import { main } from "effection";
+import { useDenoDeploy } from "@effection-contrib/deno-deploy";
+
+await main(function* () {
+  const { 
+  isDenoDeploy,
+  deploymentId,
+  region 
+  } = yield* useDenoDeploy();
+})
+```

--- a/fx/README.md
+++ b/fx/README.md
@@ -1,6 +1,9 @@
-# @effection-contrib/fx
+# fx
 
-A collection of utility functions to streamline asynchronous workflows. These
-functions were originally part of the
+A collection of utility functions to streamline asynchronous workflows.
+
+---
+
+These functions were originally part of the
 [starfx](https://github.com/neurosnap/starfx) project and have been adapted for
 use with the Effection framework.

--- a/task-buffer/README.md
+++ b/task-buffer/README.md
@@ -1,7 +1,11 @@
 # Task Buffer
 
 Manages concurrent task execution by enforcing a maximum limit on simultaneously
-active operations. When this limit is reached, the `TaskBuffer` automatically
+active operations.
+
+---
+
+When this limit is reached, the `TaskBuffer` automatically
 queues additional spawn requests and processes them in order as capacity becomes
 available. This prevents resource overload while ensuring all tasks are
 eventually executed.

--- a/task-buffer/README.md
+++ b/task-buffer/README.md
@@ -5,10 +5,9 @@ active operations.
 
 ---
 
-When this limit is reached, the `TaskBuffer` automatically
-queues additional spawn requests and processes them in order as capacity becomes
-available. This prevents resource overload while ensuring all tasks are
-eventually executed.
+When this limit is reached, the `TaskBuffer` automatically queues additional
+spawn requests and processes them in order as capacity becomes available. This
+prevents resource overload while ensuring all tasks are eventually executed.
 
 ```ts
 import { run, sleep } from "effection";

--- a/tinyexec/README.md
+++ b/tinyexec/README.md
@@ -3,6 +3,8 @@
 Effection compatible wrapper around
 [tinyexec](https://www.npmjs.com/package/tinyexec) package.
 
+---
+
 To run a process, use the `x` function:
 
 ```ts

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -1,26 +1,34 @@
 # WebSocket
 
-Use the [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
-API as an Effection resource. Instead of a fragile, spring-loaded confederation
-of 'open', 'close', 'error', and 'message' event handlers, `useWebSocket()`
-organizes them for you so that you can consume all events from the server as a
-plain stream that has state-readiness and proper error handling baked in.
+A streamlined [WebSocket][websocket] client for Effection programs that transforms the
+event-based WebSocket API into a clean, resource-oriented stream.
 
----
+## Why Use this API?
 
-To use a websocket import the `useWebSocket()` operation which behaves just like
-the [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
-constructor.
+Traditional WebSocket API require managing multiple event handlers (`open`,
+`close`, `error`, `message`) which can become complex and error-prone.
 
-```ts
+This package simplifies WebSocket usage by:
+
+- Providing a clean stream-based interface
+- Handling connection state management automatically
+- Implementing proper error handling
+- Ensuring resource cleanup
+
+## Basic Usage
+
+```typescript
 import { each, main } from "effection";
 import { useWebSocket } from "@effection-contrib/websocket";
 
 await main(function* () {
+  // Connection is guaranteed to be open when this returns
   let socket = yield* useWebSocket("ws://websocket.example.org");
 
+  // Send messages to the server
   socket.send("Hello World");
 
+  // Receive messages using a simple iterator
   for (let message of yield* each(socket)) {
     console.log("Message from server", message);
     yield* each.next();
@@ -28,20 +36,27 @@ await main(function* () {
 });
 ```
 
-The resource provides the following niceties:
+## Features
 
-- When `useWebSocket()` returns, it will have already received the `open` event.
-- If the socket recieves an error event, that event's error will be thrown to
-  the current error boundary.
-- The socket is a stream whose items are each `MessageEvents`, the `CloseEvent`
-  of the websocket will be the close event of that stream.
+- **Ready-to-use Connections**: `useWebSocket()` returns only after the
+  connection is established
+- **Automatic Error Handling**: Socket errors are properly propagated to your
+  error boundary
+- **Stream-based API**: Messages are delivered through a simple stream interface
+- **Clean Resource Management**: Connections are properly cleaned up when the
+  operation completes
 
-You can also instantiate a websocket separately and pass it along to
-`useWebSocket()`. This is helpful for runtimes such as NodeJS prior to version
-21 that do not have built in support for websocket.
+## Advanced Usage
 
-```ts
+### Custom WebSocket Implementations
+
+For environments without native WebSocket support (like Node.js < 21), you can
+provide your own WebSocket implementation:
+
+```typescript
 import { createWebSocket } from "my-websocket-client";
+import { each, main } from "effection";
+import { useWebSocket } from "@effection-contrib/websocket";
 
 await main(function* () {
   let socket = yield* useWebSocket(() =>
@@ -54,3 +69,5 @@ await main(function* () {
   }
 });
 ```
+
+[websocket]: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -1,7 +1,7 @@
 # WebSocket
 
-A streamlined [WebSocket][websocket] client for Effection programs that transforms the
-event-based WebSocket API into a clean, resource-oriented stream.
+A streamlined [WebSocket][websocket] client for Effection programs that
+transforms the event-based WebSocket API into a clean, resource-oriented stream.
 
 ## Why Use this API?
 


### PR DESCRIPTION
## Motivation

I'm setting up search and I want to have consistent results for contributing package names.

## Approach

1. Use a consistent h1 in the readmes
2. Enchanged websocket readme with Claude.ai
