### PR TITLE
Moved shared code into another module

### DIFF
--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -1,16 +1,15 @@
-import { build, emptyDir } from "jsr:@deno/dnt";
-import { DenoJson } from "./publish-matrix.ts";
-
-const outDir = "./build/npm";
-
-await emptyDir(outDir);
+import { build, emptyDir } from "jsr:@deno/dnt@0.41.3";
+import { DenoJson } from "./lib/read-packages.ts";
+import { join } from "jsr:@std/path@^1.0.7/join";
 
 let [workspace] = Deno.args;
 if (!workspace) {
-  throw new Error("a version argument is required to build the npm package");
+  throw new Error("workspace path is required build npm package");
 }
 
-let mod = await import(`../../${workspace}/deno.json`, {
+Deno.chdir(workspace);
+
+let mod = await import(join(Deno.cwd(), `/deno.json`), {
   with: { type: "json" },
 });
 
@@ -24,7 +23,9 @@ let entryPoints = typeof deno.exports === "string"
     path,
   }));
 
-Deno.chdir(workspace);
+const outDir = "./build/npm";
+
+await emptyDir(outDir);
 
 await build({
   entryPoints,

--- a/tasks/lib/read-packages.ts
+++ b/tasks/lib/read-packages.ts
@@ -1,0 +1,44 @@
+import { call, type Operation } from "effection";
+import { resolve } from "jsr:@std/path@^1.0.6";
+import { z } from "npm:zod@3.23.8";
+
+export const DenoJson = z.object({
+  name: z.string(),
+  version: z.string(),
+  exports: z.union([z.record(z.string()), z.string()]),
+  license: z.string(),
+});
+
+export type PackageConfig = {
+  workspace: string;
+  workspacePath: string;
+} & z.infer<typeof DenoJson>;
+
+export function* readPackages(): Operation<PackageConfig[]> {
+  const root = yield* call(() =>
+    import("../../deno.json", {
+      with: { type: "json" },
+    })
+  );
+
+  console.log(`Found ${root.default.workspace.join(", ")}`);
+
+  const configs: PackageConfig[] = [];
+  for (let workspace of root.default.workspace) {
+    const workspacePath = resolve(Deno.cwd(), workspace);
+
+    const config = yield* call(() =>
+      Deno.readTextFile(`${workspacePath}/deno.json`)
+    );
+
+    const denoJson = DenoJson.parse(JSON.parse(config));
+
+    configs.push({
+      ...denoJson,
+      workspace: workspace.replace("./", ""),
+      workspacePath,
+    });
+  }
+
+  return configs;
+}


### PR DESCRIPTION
## Motivation

3rd time was not the charm. I don't know what happened to this build script, but it was all kinds of out of wack.

## Approach

- Moved shared code into a different module to prevent publish-matrix.ts from being evaluated.
- Reorganized the build script
