### PR TITLE
Remove reference to WorkerOptions

### DIFF
--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -199,7 +199,7 @@ export async function workerMain<TSend, TRecv, TReturn, TData>(
  * ```
  *
  * @param url URL or string of script
- * @param options {WorkerOptions}
+ * @param options WorkerOptions
  * @template TSend - value main thread will send to the worker
  * @template TRecv - value main thread will receive from the worker
  * @template TReturn - worker operation return value


### PR DESCRIPTION
## Motivation

MDX evaluates JSDOC content as JS and it struggles to parse content in `{/* reference in here get confused */}` . We'll need to figure out how to fix this in effection-www.

## Approach

Just removed a reference that caused problems.