### PR TITLE
Test Adapter

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -28,6 +28,7 @@
     "./jsonl-store",
     "./fx",
     "./task-buffer",
+    "./test-adapter",
     "./tinyexec",
     "./timebox",
     "./websocket",

--- a/test-adapter/README.md
+++ b/test-adapter/README.md
@@ -1,0 +1,38 @@
+# Test Adapter
+
+An abstract helper for integrating Effection with testing frameworks.
+
+---
+
+Typically, you won't use this module directly, but instead you'll use one of the
+actual testing framework integrations. The following shows how you might
+integrate it with the `@std/bdd` module. You would never use it this way, this
+demonstrates the general pattern of lifecycle.
+
+```ts
+import { run, sleep } from "effection";
+import { createTestAdapter, TestAdapter } from "@effection-contrib/test-adapter";
+import { describe, it, beforeEach } from "@std/bdd";
+
+
+describe("something", () => {
+  let adapter: TestAdapter;
+  beforeAll(() => {)
+    adapter = createTestAdapter("something");
+  });
+  
+  afterAll(() => adapter.destroy())
+  
+  adapter.addSetup(function*() {
+    /* do some setup. equivalent of beforeEach() */
+	/* contexts set here will be visible in the test */*
+  });
+  
+  it("does a thing", async () => {
+    await adapter.runTest(function*() {
+	  /* ... the body of the test */
+	});
+  });
+
+});
+```

--- a/test-adapter/deno.json
+++ b/test-adapter/deno.json
@@ -1,0 +1,6 @@
+{
+  "name": "@effection-contrib/test-adapter",
+  "version": "0.1.0",
+  "license": "MIT",
+  "exports": "./mod.ts"
+}

--- a/test-adapter/mod.ts
+++ b/test-adapter/mod.ts
@@ -29,7 +29,7 @@ const anonymousNames: Iterator<string, never> = (function* () {
   }
 })();
 
-export function createTestContainer(
+export function createTestAdapter(
   options: TestAdapterOptions,
 ): TestAdapter {
   let setups: TestOp[] = [];

--- a/test-adapter/mod.ts
+++ b/test-adapter/mod.ts
@@ -1,0 +1,71 @@
+import type { Future, Operation, Scope } from "npm:effection@4.0.0-alpha.5";
+import { createScope } from "npm:effection@4.0.0-alpha.5";
+
+export interface TestOp {
+  (): Operation<void>;
+}
+
+export interface TestAdapter {
+  readonly parent?: TestAdapter;
+  readonly name: string;
+  readonly fullname: string;
+  readonly scope: Scope;
+  readonly lineage: Array<TestAdapter>;
+  readonly setups: TestOp[];
+  addSetup(op: TestOp): void;
+  runTest(body: TestOp): Future<void>;
+  destroy(): Future<void>;
+}
+
+export interface TestAdapterOptions {
+  name?: string;
+  parent?: TestAdapter;
+}
+
+const anonymousNames: Iterator<string, never> = (function* () {
+  let count = 1;
+  while (true) {
+    yield `anonymous test adapter ${count++}`;
+  }
+})();
+
+export function createTestContainer(
+  options: TestAdapterOptions,
+): TestAdapter {
+  let setups: TestOp[] = [];
+  let { parent, name = anonymousNames.next().value } = options;
+
+  let [scope, destroy] = createScope(parent?.scope);
+
+  let adapter: TestAdapter = {
+    parent,
+    name,
+    scope,
+    setups,
+    get lineage() {
+      let lineage = [adapter];
+      for (let current = parent; current; current = current.parent) {
+        lineage.unshift(current);
+      }
+      return lineage;
+    },
+    get fullname() {
+      return adapter.lineage.map((adapter) => adapter.name).join(" > ");
+    },
+    addSetup(op) {
+      setups.push(op);
+    },
+    runTest(op) {
+      return scope.run(function* () {
+	let allSetups = adapter.lineage.reduce((all, adapter) => all.concat(adapter.setups),[] as TestOp[])
+	for (let setup of allSetups) {
+	  yield* setup();
+	}
+        yield* op();
+      });
+    },
+    destroy,
+  };
+
+  return adapter;
+}

--- a/test-adapter/mod.ts
+++ b/test-adapter/mod.ts
@@ -85,7 +85,7 @@ const anonymousNames: Iterator<string, never> = (function* () {
  * Create a new test adapter with the given options.
  */
 export function createTestAdapter(
-  options: TestAdapterOptions,
+  options: TestAdapterOptions = {},
 ): TestAdapter {
   let setups: TestOperation[] = [];
   let { parent, name = anonymousNames.next().value } = options;

--- a/test-adapter/mod.ts
+++ b/test-adapter/mod.ts
@@ -1,24 +1,76 @@
 import type { Future, Operation, Scope } from "npm:effection@4.0.0-alpha.5";
 import { createScope } from "npm:effection@4.0.0-alpha.5";
 
-export interface TestOp {
+export interface TestOperation {
   (): Operation<void>;
 }
 
 export interface TestAdapter {
+  /**
+   * The parent of this adapter. All of the setup from this adapter will be
+   * run in addition to the setup of this adapter during `runTest()`
+   */
   readonly parent?: TestAdapter;
+
+  /**
+   * The name of this adapter which is mostly useful for debugging purposes
+   */
   readonly name: string;
+
+  /**
+   * A qualified name that contains not only the name of this adapter, but of all its
+   * ancestors. E.g. `All Tests > File System > write`
+   */
   readonly fullname: string;
+
+  /**
+   * Every test adapter has its own Effection `Scope` which holds the resources necessary
+   * to run this test.
+   */
   readonly scope: Scope;
+
+  /**
+   * A list of this test adapter and every adapter that it descends from.
+   */
   readonly lineage: Array<TestAdapter>;
-  readonly setups: TestOp[];
-  addSetup(op: TestOp): void;
-  runTest(body: TestOp): Future<void>;
+
+  /**
+   * The setup operations that will be run by this test adapter. It only includes those
+   * setups that are associated with this adapter, not those of its ancestors.
+   */
+  readonly setups: TestOperation[];
+
+  /**
+   * Add a setup operation to every test that is part of this adapter. In BDD integrations,
+   * this is usually called by `beforEach()`
+   */
+  addSetup(op: TestOperation): void;
+
+  /**
+   * Actually run a test. This evaluates all setup operations, and then after those have completed
+   * it runs the body of the test itself.
+   */
+  runTest(body: TestOperation): Future<void>;
+
+  /**
+   * Teardown this test adapter and all of the task and resources that are running inside it.
+   * This basically destroys the Effection `Scope` associated with this adapter.
+   */
   destroy(): Future<void>;
 }
 
 export interface TestAdapterOptions {
+  /**
+   * The name of this test adapter which is handy for debugging.
+   * Usually, you'll give this the same name as the current test
+   * context. For example, when integrating with BDD, this would be
+   * the same as
+   */
   name?: string;
+  /**
+   * The parent test adapter. All of the setup from this adapter will be
+   * run in addition to the setup of this adapter during `runTest()`
+   */
   parent?: TestAdapter;
 }
 
@@ -29,10 +81,13 @@ const anonymousNames: Iterator<string, never> = (function* () {
   }
 })();
 
+/**
+ * Create a new test adapter with the given options.
+ */
 export function createTestAdapter(
   options: TestAdapterOptions,
 ): TestAdapter {
-  let setups: TestOp[] = [];
+  let setups: TestOperation[] = [];
   let { parent, name = anonymousNames.next().value } = options;
 
   let [scope, destroy] = createScope(parent?.scope);
@@ -57,10 +112,13 @@ export function createTestAdapter(
     },
     runTest(op) {
       return scope.run(function* () {
-	let allSetups = adapter.lineage.reduce((all, adapter) => all.concat(adapter.setups),[] as TestOp[])
-	for (let setup of allSetups) {
-	  yield* setup();
-	}
+        let allSetups = adapter.lineage.reduce(
+          (all, adapter) => all.concat(adapter.setups),
+          [] as TestOperation[],
+        );
+        for (let setup of allSetups) {
+          yield* setup();
+        }
         yield* op();
       });
     },

--- a/test-adapter/test/adapter.test.ts
+++ b/test-adapter/test/adapter.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "jsr:@std/testing/bdd";
+import { expect } from "jsr:@std/expect";
+import { createTestAdapter } from "../mod.ts";
+import { createContext } from "npm:effection@4.0.0-alpha.7";
+
+describe("TestAdapter", () => {
+  it("can run a test", async () => {
+    let adapter = createTestAdapter();
+    let result: string = "pending";
+    await adapter.runTest(function* () {
+      result = "done";
+    });
+
+    expect(result).toEqual("done");
+  });
+  it("runs hierarchical setup within a scope", async () => {
+    let count = createContext<number>("count", 1);
+
+    function* update() {
+      let current = yield* count.expect();
+      yield* count.set(current * 2);
+    }
+    let grandparent = createTestAdapter({ name: "grandparent" });
+    let parent = createTestAdapter({ name: "parent", parent: grandparent });
+    let child = createTestAdapter({ name: "child", parent });
+
+    grandparent.addSetup(update);
+    parent.addSetup(update);
+    child.addSetup(update);
+
+    await child.runTest(function* () {
+      expect(yield* count.expect()).toEqual(8);
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

It's nice to be able to use Effection operations as the native currency of your tests since it lets you use all the Effection-y goodness like contexts, resources, etc.. right inside your tests!

## Approach

This provides a test adapter that can be used to integrate with various testing frameworks out there. It isn't meant to be used by itself so much as to be used by framework integrations. This is an extraction of the `TestAdapter` written to integrate with vitest.

