### PR TITLE
remove top level await in main module

### DIFF
--- a/watch/main.ts
+++ b/watch/main.ts
@@ -7,7 +7,7 @@ import denoJson from "./deno.json" with { type: "json" };
 
 const builtins = ["-h", "--help", "-V", "--version"];
 
-await main(function* (argv) {
+main(function* (argv) {
   let { args, rest } = extract(argv);
   parser()
     .name("watch")


### PR DESCRIPTION
## Motivation

Apparently, no top level awaits are allowed in cjs modules.
